### PR TITLE
Feature/handle update serial cmdline err

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Configuration
 zones_src_path | - | - | yes | ユーザが編集するゾーンファイルのディレクトリ (絶対パスまたは nsmgmt.conf からの相対パス)
 zones_dst_path | - | - | yes | ゾーンファイルの出力先 (絶対パスまたは nsmgmt.conf からの相対パス)
 update_serial | 0,1 | 1 | no | ゾーンファイルの出力時に SOA のシリアル値を更新するかどうか (0:しない, 1:する)
-update_serial_cmdline | - | cat | no | SOA のシリアル値を更新するためのコマンドライン (標準入力に更新前のゾーンファイルの内容が与えられる)
+update_serial_cmdline | - | cat | no | SOA のシリアル値を更新するためのコマンドライン (標準入力に更新前のゾーンファイルの内容が与えられる。0 以外で終了すると続く処理を行わない)
 tasks | - | () | no | ゾーンファイルに変更が合った場合に実行されるコマンドラインの配列 (コンフィグの生成やサーバのリロード等)
 pre_process_cmdline | - | "" | no | 処理前に実行するコマンドライン (0 以外で終了すると続く処理を行わない)
 post_process_cmdline | - | "" | no | 処理後に実行するコマンドライン

--- a/libexec/nsmgmt.sh
+++ b/libexec/nsmgmt.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -e
+set -o pipefail
 
 readonly BIN_DIR=$(cd ${BASH_SOURCE[0]%/*} && pwd)
 readonly LIB_DIR=${BIN_DIR}/../libexec
@@ -135,11 +136,22 @@ function update_added_zones() {
         NEED_TASKS=1
     fi
 
+    local retval=0
+
     cd ${ZONES_TMP_DIR}
 
     if [ ${update_serial} -eq 1 ]; then
         while [ ${i} -lt ${len} ]; do
+            set +e
             cat ${ADDED_ZONES[${i}]} | eval "${update_serial_cmdline}" > ${zones_dst_path}/${ADDED_ZONES[${i}]}
+            retval=$?
+            set -e
+
+            if [ ${retval} -ne 0 ]; then
+                echo "update_serial_cmdline command for \"${ADDED_ZONES[${i}]}\" returns ${retval}"
+                exit 1
+            fi
+
             i=$((i + 1))
         done
     else
@@ -172,11 +184,22 @@ function update_changed_zones() {
         NEED_TASKS=1
     fi
 
+    local retval=0
+
     cd ${ZONES_TMP_DIR}
 
     if [ ${update_serial} -eq 1 ]; then
         while [ ${i} -lt ${len} ]; do
+            set +e
             cat ${CHANGED_ZONES[${i}]} | eval "${update_serial_cmdline}" > ${zones_dst_path}/${CHANGED_ZONES[${i}]}
+            retval=$?
+            set -e
+
+            if [ ${retval} -ne 0 ]; then
+                echo "update_serial_cmdline command for \"${CHANGED_ZONES[${i}]}\" returns ${retval}"
+                exit 1
+            fi
+
             i=$((i + 1))
         done
     else

--- a/libexec/nsmgmt.sh
+++ b/libexec/nsmgmt.sh
@@ -234,9 +234,7 @@ function run_tasks() {
     local len=${#tasks[@]}
     while [ ${i} -lt ${len} ]; do
         set +e
-
         ${tasks[${i}]} | awk -v idx="[$((i + 1))]" '{print idx,$0;fflush()}'
-
         set -e
 
         i=$((i + 1))


### PR DESCRIPTION
update_serial_cmdline のエラーが考慮されない場合があるので、その修正です。

---

- [612806a: R3](https://github.com/directorz/nsmgmt/commit/612806a828bc8f36295d88e6ddf0f2fd39f0c1c8#diff-ef731d2ab2a840159aeed76a0fd8cc47ce7d1babc9cbe406f80345055c3d3157R3)
  - update_serial_cmdline で指定されているコマンドラインでパイプを使用している場合、パイプラインでエラーが起きても、以降の終了コードが 0 であれば、パイプラインの終了コードが 0 となり、スクリプト nsmgmt.sh は終了せずに後の処理へ進んでしまう。
  - 結果、update_serial_cmdline の空の出力がそのまま使用され、ゾーンファイルが空になる。
  - pipefail を設定することで、パイプラインの終了コードは、全コマンドの 0 以外の最後の終了コードになり、パイプライン内でのエラーをハンドリングできるようになる。
- [612806a: R139-R202](https://github.com/directorz/nsmgmt/commit/612806a828bc8f36295d88e6ddf0f2fd39f0c1c8#diff-ef731d2ab2a840159aeed76a0fd8cc47ce7d1babc9cbe406f80345055c3d3157R139-R202)
  - update_serial_cmdline でエラーが起きた場合は、その旨を出力して終了するようにした。